### PR TITLE
refactor: update imports fo types from a centralized place and clean …

### DIFF
--- a/src/app/journal/new/page.tsx
+++ b/src/app/journal/new/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Category } from '../../../types/journal';
+import { Category } from '../../../types/models';
 
 function NewJournalEntryContent() {
   const router = useRouter();

--- a/src/app/journal/view/page.tsx
+++ b/src/app/journal/view/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { JournalEntry, Activity, Category } from '../../../types/journal';
+import { JournalEntry, Activity, Category } from '../../../types/models';
 
 export default function ViewJournalEntries() {
     const [entries, setEntries] = useState<JournalEntry[]>([]);

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,50 +4,8 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
+import { SearchResult, Summary } from '../../types/agents';
 
-// --- Type Definitions ---
-interface Tag {
-    id: string;
-    name: string;
-}
-
-interface Activity {
-    id: string;
-    description: string;
-    duration: number | null;
-    notes: string | null;
-    category: {
-        id: string;
-        name: string;
-        color: string;
-    };
-    journalEntry: {
-        date: Date;
-    };
-    tags: { name: string }[];
-}
-
-interface SummarySection {
-    title: string;
-    content: string;
-}
-
-interface TimeSpent {
-    totalMinutes?: number;
-    breakdown?: string;
-}
-
-interface Summary {
-    mainSummary: string;
-    sections?: SummarySection[];
-    timeSpent?: TimeSpent;
-}
-
-interface SearchResult {
-    summary: Summary;
-    activities: Activity[];
-    keywords: string[];
-}
 
 // --- Helper Components ---
 const formatDate = (dateString: string) => {

--- a/src/components/CategoryManager.tsx
+++ b/src/components/CategoryManager.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Category } from '../types/journal';
+import { Category } from '../types/models';
 
 interface CategoryManagerProps {
   onCategorySelect?: (category: Category) => void;

--- a/src/lib/importAgent.ts
+++ b/src/lib/importAgent.ts
@@ -3,7 +3,7 @@
 import { OpenAI } from 'openai';
 import * as z from 'zod/v4';
 import { PrismaClient } from '@prisma/client';
-import { Category } from '../types/journal';
+import { Category } from '../types/models';
 
 // Instantiate Prisma client here for direct database access
 const prisma = new PrismaClient();

--- a/src/lib/reportAgent.ts
+++ b/src/lib/reportAgent.ts
@@ -1,25 +1,12 @@
 import * as z from 'zod/v4';
 import { OpenAI } from 'openai';
+import { Activity } from '../types/models';
 
 
 const openai = new OpenAI({
     baseURL: process.env.LLM_API_URL,
     apiKey: 'ollama', // Required but not used for local Ollama
 });
-
-// --- Type Definitions ---
-type ActivityForReport = {
-    description: string;
-    duration: number | null;
-    notes: string | null;
-    category: {
-        id: string;
-        name: string;
-        color: string;
-    };
-    journalEntry: { date: Date };
-    tags: { name: string }[];
-};
 
 // --- Zod Schemas for LLM Output Validation ---
 export const WeeklyReportSchema = z.object({
@@ -49,7 +36,7 @@ export type WeeklyReportContent = z.infer<typeof WeeklyReportSchema>;
 
 // --- Prompt Engineering ---
 
-function createWeeklyReportPrompt(activities: ActivityForReport[], schema: any): string {
+function createWeeklyReportPrompt(activities: Activity[], schema: any): string {
     const activityContext = activities.map(act => {
         const date = new Date(act.journalEntry.date).toISOString().split('T')[0];
         const duration = act.duration ? `${act.duration}min` : 'N/A';
@@ -79,7 +66,7 @@ Notes: ${act.notes || 'N/A'}`;
 
 // --- Agent Functions ---
 
-export async function generateWeeklyReport(activities: ActivityForReport[]): Promise<WeeklyReportContent | null> {
+export async function generateWeeklyReport(activities: Activity[]): Promise<WeeklyReportContent | null> {
     if (activities.length === 0) {
         return null;
     }

--- a/src/lib/searchAgent.ts
+++ b/src/lib/searchAgent.ts
@@ -2,6 +2,7 @@
 
 import { OpenAI } from 'openai';
 import * as z from 'zod/v4';
+import { Activity } from '../types/models';
 
 const openai = new OpenAI({
     baseURL: process.env.LLM_API_URL,
@@ -28,23 +29,6 @@ const SummarySchema = z.object({
         breakdown: z.string().optional().describe("A brief breakdown of how time was spent across different activities")
     }).optional().describe("Information about time allocation, if relevant to the query")
 });
-
-// --- Helper Types ---
-interface Activity {
-    id: string;
-    description: string;
-    duration: number | null;
-    notes: string | null;
-    category: {
-        id: string;
-        name: string;
-        color: string;
-    };
-    journalEntry: {
-        date: Date;
-    };
-    tags: { name: string }[];
-}
 
 
 // --- Query Planner Agent---

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -1,0 +1,28 @@
+// src/types/agents.ts
+import { Activity } from './models'; // Reuse our core model type
+
+// For Search Agent
+export interface SummarySection {
+    title: string;
+    content: string;
+}
+
+export interface TimeSpent {
+    totalMinutes?: number;
+    breakdown?: string;
+}
+
+export interface Summary {
+    mainSummary: string;
+    sections?: SummarySection[];
+    timeSpent?: TimeSpent;
+}
+
+export interface SearchResult {
+    summary: Summary;
+    activities: Activity[];
+    keywords: string[];
+}
+
+// For Report Agent
+export interface WeeklyReportContent { /* ... */ }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -27,6 +27,7 @@ export interface Activity {
   category: Category;
   categoryId: string;
   tags: Tag[];
+  journalEntry: JournalEntry;
 }
 
 export interface JournalEntry {


### PR DESCRIPTION
### **Refactor: Centralize and Organize Type Definitions**

This pull request introduces a refactoring of our application's type definitions to improve organization, reduce duplication, and establish a single source of truth for our data models. This addresses growing technical debt from locally defined and redundant types across different features and agents.

#### **Summary of Changes:**

*   **Centralized Core Models:**
    *   Renamed `src/types/journal.ts` to `src/types/models.ts`. This better reflects that these types (`Activity`, `JournalEntry`, `Category`) are the core data models for the application, not just the journal feature.
    *   Updated all relevant component and agent imports to point to this new canonical location.

*   **Created Agent-Specific Type Definitions:**
    *   Introduced a new file, `src/types/agents.ts`, to house types that are specific to the data structures used by our AI agents (e.g., `SearchResult`, `Summary`).
    *   This separates the core application models from the transient, agent-specific data contracts.

*   **Eliminated Type Duplication (DRY):**
    *   Removed redundant, locally-defined `Activity` and `Summary`-related interfaces from `search/page.tsx`, `lib/reportAgent.ts`, and `lib/searchAgent.ts`.
    *   These modules now import their types from `types/models.ts` and `types/agents.ts`, ensuring consistency and a single source of truth.

*   **Improved `Activity` Model:**
    *   The `Activity` type in `models.ts` has been enhanced to include its parent `journalEntry`. This makes the `Activity` object more self-contained and useful, eliminating the need for ad-hoc types like `ActivityForReport` that were previously used to pass date context to our agents.

#### **Impact:**

This refactoring improves the maintainability and scalability of the codebase. By enforcing a single source of truth for types, we reduce the risk of bugs caused by inconsistent data structures and make future development more efficient.